### PR TITLE
feat: 변경된 URI 및 로깅 기능 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,12 +57,55 @@ docker-compose up -d
 
 ## 3. 주요 기능
 - **실험 생성**: Admin API를 통해 실험(Variants, 타겟팅 규칙)을 생성합니다.
-- **트래픽 분배**: API 서버(`/v1/assign`)를 통해 사용자를 그룹에 할당합니다.
+- **트래픽 분배**: API 서버(`GET /v1/assign`)를 통해 사용자를 그룹에 할당합니다.
 - **로그 수집**: 할당 및 전환 로그가 비동기로 DB에 저장됩니다.
+  - 할당 로그: `GET /v1/assign` 호출 시 자동 기록
+  - 전환 로그: `POST /v1/conversions` 호출 시 기록
 - **통계 분석**: Admin API를 통해 실험별 CVR(전환율)과 승자를 확인합니다.
 
 ## 4. 클라이언트 연동 (Client Integration)
 Prism은 Java/Kotlin 애플리케이션을 위한 공식 SDK를 제공합니다.
+
+### SDK 설계 원칙: 안전 우선 (Fail-safe)
+
+Prism SDK는 **"A/B 테스트 실패가 메인 비즈니스 로직을 중단시키지 않는다"**는 원칙으로 설계되었습니다.
+
+#### 핵심 동작 방식
+
+**1. `assign()` - Variant 할당 (안전한 응답)**
+- API 호출 실패 시 **예외를 던지지 않고** 에러 응답을 반환합니다
+- `variant`가 `null`이면 실패한 것으로 판단하고 기본값을 사용합니다
+- 모든 에러는 로그에 기록됩니다
+
+```kotlin
+// Kotlin
+val response = prismClient.assign("user-123", "exp-1")
+val variant = response.variant ?: "control"  // null이면 기본값 사용
+
+// Java
+AssignmentResponse response = client.assign("user-123", "exp-1");
+String variant = response.getVariant() != null ? response.getVariant() : "control";
+```
+
+**2. `trackConversion()` - 전환 추적 (조용히 실패)**
+- 실패 시 로그만 기록하고 예외를 던지지 않습니다 (fire-and-forget)
+- 메인 비즈니스 로직에 영향을 주지 않습니다
+
+```kotlin
+// Kotlin
+prismClient.trackConversion("user-123", "exp-1", "purchase")
+// 실패해도 앱이 중단되지 않음
+
+// Java
+client.trackConversion("user-123", "exp-1", "purchase");
+```
+
+#### 안전 우선 방식의 장점
+- ✅ API 서버 다운 시에도 앱이 정상 동작
+- ✅ 네트워크 오류로 앱이 크래시 나지 않음
+- ✅ A/B 테스트 실패 시 자동으로 기본값(control) 사용
+- ✅ 간단한 사용법 (try-catch 불필요)
+- ✅ Java/Kotlin 모두 자연스럽게 사용 가능
 
 ### Gradle 설정
 `prism-spring-boot-starter`를 사용하면 별도의 설정 없이 Spring 환경에서 쉽게 사용할 수 있습니다.
@@ -72,6 +115,71 @@ implementation("io.github.silbaram.prism:prism-spring-boot-starter:0.0.1-SNAPSHO
 ```
 
 더 자세한 사용법은 [prism-spring-boot-starter README](prism-spring-boot-starter/README.md) 또는 [prism-sdk README](prism-sdk/README.md)를 참고하세요.
+
+### SDK 직접 사용 (Pure SDK Usage)
+Spring Boot가 아닌 환경이나 더 세밀한 제어가 필요한 경우 `PrismClient`를 직접 사용할 수 있습니다.
+
+#### 1. 의존성 추가
+```kotlin
+dependencies {
+    implementation("io.github.silbaram.prism:prism-sdk:0.0.1-SNAPSHOT")
+}
+```
+
+#### 2. PrismClient 생성 및 사용
+```kotlin
+import io.github.silbaram.prism.sdk.PrismClient
+import java.time.Duration
+
+// 클라이언트 생성
+val client = PrismClient(
+    baseUrl = "http://localhost:8081",
+    timeout = Duration.ofSeconds(5)
+)
+
+// Variant 할당 (안전한 방식)
+val response = client.assign("user-123", "discount_experiment")
+val variant = response.variant ?: "control"  // null이면 기본값 사용
+
+// 비즈니스 로직 적용
+when (variant) {
+    "A" -> applyDiscount10Percent()
+    "B" -> applyDiscount20Percent()
+    else -> noDiscount()
+}
+
+// 전환 추적 (구매 완료 시)
+client.trackConversion("user-123", "discount_experiment", "purchase")
+```
+
+#### 3. Java에서 사용
+```java
+import io.github.silbaram.prism.sdk.PrismClient;
+import io.github.silbaram.prism.common.rest.dto.assign.AssignmentResponse;
+import java.time.Duration;
+
+// 클라이언트 생성
+PrismClient client = new PrismClient(
+    "http://localhost:8081",
+    Duration.ofSeconds(5)
+);
+
+// Variant 할당
+AssignmentResponse response = client.assign("user-123", "discount_experiment");
+String variant = response.getVariant() != null ? response.getVariant() : "control";
+
+// 비즈니스 로직 적용
+if ("A".equals(variant)) {
+    applyDiscount10Percent();
+} else if ("B".equals(variant)) {
+    applyDiscount20Percent();
+} else {
+    noDiscount();
+}
+
+// 전환 추적
+client.trackConversion("user-123", "discount_experiment", "purchase");
+```
 
 ### 어노테이션 기반 사용법 (Annotation-based Usage)
 Spring Boot 환경에서는 `@PrismExperiment` 어노테이션을 사용하여 A/B 테스트를 간편하게 적용할 수 있습니다.

--- a/prism-api/src/main/kotlin/io/github/silbaram/prism/api/conversion/controller/ConversionController.kt
+++ b/prism-api/src/main/kotlin/io/github/silbaram/prism/api/conversion/controller/ConversionController.kt
@@ -26,7 +26,7 @@ import org.springframework.web.bind.annotation.RestController
  * 웹 계층과 애플리케이션 계층을 연결하는 어댑터 역할만 수행합니다.
  */
 @RestController
-@RequestMapping("/v1/events")
+@RequestMapping("/v1/conversions")
 class ConversionController(
     private val trackConversionUseCase: TrackConversionUseCase
 ) {
@@ -36,7 +36,7 @@ class ConversionController(
      *
      * ## API 명세
      * - Method: POST
-     * - Path: /v1/events/conversion
+     * - Path: /v1/conversions
      * - Body: ConversionRequest
      *
      * ## 처리 흐름
@@ -47,7 +47,7 @@ class ConversionController(
      * @param request 전환 이벤트 요청
      * @return 전환 추적 결과
      */
-    @PostMapping("/conversion")
+    @PostMapping
     fun trackConversion(@RequestBody request: ConversionRequest): ConversionResponse {
         // 1단계: Command 생성
         val command = TrackConversionCommand(

--- a/prism-sdk/build.gradle.kts
+++ b/prism-sdk/build.gradle.kts
@@ -18,6 +18,9 @@ dependencies {
     // JSON 직렬화 등 런타임 의존성
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.15.2")
 
+    // 로깅 의존성
+    implementation("org.slf4j:slf4j-api:2.0.9")
+
     // 테스트 의존성
     testImplementation(kotlin("test"))
     testImplementation("com.squareup.okhttp3:mockwebserver:4.11.0")

--- a/prism-sdk/src/main/kotlin/io/github/silbaram/prism/sdk/PrismClient.kt
+++ b/prism-sdk/src/main/kotlin/io/github/silbaram/prism/sdk/PrismClient.kt
@@ -4,12 +4,21 @@ import io.github.silbaram.prism.common.rest.dto.assign.AssignmentResponse
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.github.silbaram.prism.common.rest.dto.conversion.ConversionRequest
+import org.slf4j.LoggerFactory
 import java.net.URI
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
 import java.time.Duration
 
+/**
+ * Prism A/B 테스트 플랫폼의 Java/Kotlin 클라이언트 SDK.
+ *
+ * 이 클라이언트는 "안전 우선(Fail-safe)" 방식으로 설계되었습니다:
+ * - API 호출 실패 시 예외를 던지지 않고 에러 응답을 반환합니다.
+ * - A/B 테스트 실패가 메인 비즈니스 로직을 중단시키지 않습니다.
+ * - 모든 에러는 로그에 기록됩니다.
+ */
 class PrismClient(
     private val baseUrl: String,
     private val timeout: Duration = Duration.ofSeconds(5)
@@ -20,41 +29,114 @@ class PrismClient(
 
     private val objectMapper = jacksonObjectMapper()
 
-    fun assign(userId: String, experimentKey: String): AssignmentResponse {
-        val uri = URI.create("$baseUrl/v1/assign?userId=$userId&experimentKey=$experimentKey")
-        val request = HttpRequest.newBuilder()
-            .uri(uri)
-            .GET()
-            .build()
-
-        val response = client.send(request, HttpResponse.BodyHandlers.ofString())
-
-        if (response.statusCode() != 200) {
-            throw RuntimeException("Failed to assign variant: ${response.statusCode()} - ${response.body()}")
-        }
-
-        return objectMapper.readValue(response.body())
+    companion object {
+        private val logger = LoggerFactory.getLogger(PrismClient::class.java)
     }
 
-    fun trackConversion(userId: String, experimentKey: String, eventName: String) {
-        val uri = URI.create("$baseUrl/v1/events/conversion")
-        val payload = ConversionRequest(
-            experimentKey = experimentKey,
-            userId = userId,
-            eventName = eventName
-        )
-        val jsonBody = objectMapper.writeValueAsString(payload)
+    /**
+     * 사용자를 A/B 테스트 변형(variant)에 할당합니다.
+     *
+     * **실패 처리:**
+     * - API 호출 실패 시: resultCode가 "9999"이고 variant가 null인 응답 반환
+     * - 네트워크 오류 시: resultCode가 "9999"이고 variant가 null인 응답 반환
+     * - 모든 에러는 로그에 기록됨
+     *
+     * **사용 예시:**
+     * ```kotlin
+     * val response = prismClient.assign("user-123", "exp-1")
+     * val variant = response.variant ?: "control"  // null이면 기본값 사용
+     * ```
+     *
+     * @param userId 사용자 고유 식별자
+     * @param experimentKey 실험 키
+     * @return 할당 결과 (실패 시 variant가 null인 응답)
+     */
+    fun assign(userId: String, experimentKey: String): AssignmentResponse {
+        return try {
+            val uri = URI.create("$baseUrl/v1/assign?userId=$userId&experimentKey=$experimentKey")
+            val request = HttpRequest.newBuilder()
+                .uri(uri)
+                .GET()
+                .build()
 
-        val request = HttpRequest.newBuilder()
-            .uri(uri)
-            .header("Content-Type", "application/json")
-            .POST(HttpRequest.BodyPublishers.ofString(jsonBody))
-            .build()
+            val response = client.send(request, HttpResponse.BodyHandlers.ofString())
 
-        val response = client.send(request, HttpResponse.BodyHandlers.ofString())
-
-        if (response.statusCode() != 200) {
-            throw RuntimeException("Failed to track conversion: ${response.statusCode()} - ${response.body()}")
+            if (response.statusCode() == 200) {
+                objectMapper.readValue(response.body())
+            } else {
+                logger.warn("Failed to assign variant: HTTP ${response.statusCode()} - ${response.body()}")
+                createErrorResponse(userId, experimentKey, "HTTP ${response.statusCode()}")
+            }
+        } catch (e: Exception) {
+            logger.error("Error assigning variant for userId=$userId, experimentKey=$experimentKey", e)
+            createErrorResponse(userId, experimentKey, e.message ?: "Unknown error")
         }
+    }
+
+    /**
+     * 전환 이벤트를 추적합니다 (fire-and-forget).
+     *
+     * **실패 처리:**
+     * - 실패 시 로그만 기록하고 조용히 실패 (메인 로직에 영향 없음)
+     * - 예외를 던지지 않음
+     * - 반환값 없음
+     *
+     * **사용 예시:**
+     * ```kotlin
+     * prismClient.trackConversion("user-123", "exp-1", "purchase")
+     * // 실패해도 앱 동작에 영향 없음
+     * ```
+     *
+     * @param userId 사용자 고유 식별자
+     * @param experimentKey 실험 키
+     * @param eventName 이벤트 이름 (예: "purchase", "signup")
+     */
+    fun trackConversion(userId: String, experimentKey: String, eventName: String) {
+        try {
+            val uri = URI.create("$baseUrl/v1/conversions")
+            val payload = ConversionRequest(
+                experimentKey = experimentKey,
+                userId = userId,
+                eventName = eventName
+            )
+            val jsonBody = objectMapper.writeValueAsString(payload)
+
+            val request = HttpRequest.newBuilder()
+                .uri(uri)
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(jsonBody))
+                .build()
+
+            val response = client.send(request, HttpResponse.BodyHandlers.ofString())
+
+            if (response.statusCode() != 200) {
+                logger.warn("Failed to track conversion: HTTP ${response.statusCode()}")
+            }
+        } catch (e: Exception) {
+            logger.error("Error tracking conversion for userId=$userId, experimentKey=$experimentKey, eventName=$eventName", e)
+            // 조용히 실패 (예외 던지지 않음)
+        }
+    }
+
+    /**
+     * 에러 응답을 생성하는 내부 헬퍼 메서드.
+     *
+     * @param userId 사용자 ID
+     * @param experimentKey 실험 키
+     * @param errorMessage 에러 메시지
+     * @return 에러 응답 (variant가 null)
+     */
+    private fun createErrorResponse(
+        userId: String,
+        experimentKey: String,
+        errorMessage: String
+    ): AssignmentResponse {
+        return AssignmentResponse(
+            userId = userId,
+            experimentKey = experimentKey,
+            variant = null,
+            resultCode = "9999",
+            resultMessage = "Assignment failed: $errorMessage"
+        )
     }
 }

--- a/prism-sdk/src/main/kotlin/io/github/silbaram/prism/sdk/PrismClient.kt
+++ b/prism-sdk/src/main/kotlin/io/github/silbaram/prism/sdk/PrismClient.kt
@@ -6,9 +6,12 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import io.github.silbaram.prism.common.rest.dto.conversion.ConversionRequest
 import org.slf4j.LoggerFactory
 import java.net.URI
+import java.net.URLEncoder
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
+import java.net.http.HttpTimeoutException
+import java.nio.charset.StandardCharsets
 import java.time.Duration
 
 /**
@@ -31,6 +34,13 @@ class PrismClient(
 
     companion object {
         private val logger = LoggerFactory.getLogger(PrismClient::class.java)
+
+        // HTTP 상태 코드
+        private const val HTTP_OK = 200
+
+        // 응답 코드
+        private const val SUCCESS_CODE = "0000"
+        private const val ERROR_CODE = "9999"
     }
 
     /**
@@ -52,23 +62,49 @@ class PrismClient(
      * @return 할당 결과 (실패 시 variant가 null인 응답)
      */
     fun assign(userId: String, experimentKey: String): AssignmentResponse {
+        val maskedUserId = maskUserId(userId)
+
         return try {
-            val uri = URI.create("$baseUrl/v1/assign?userId=$userId&experimentKey=$experimentKey")
+            // URL 파라미터 인코딩 (특수문자 대응)
+            val encodedUserId = URLEncoder.encode(userId, StandardCharsets.UTF_8)
+            val encodedExperimentKey = URLEncoder.encode(experimentKey, StandardCharsets.UTF_8)
+            val uri = URI.create("$baseUrl/v1/assign?userId=$encodedUserId&experimentKey=$encodedExperimentKey")
+
             val request = HttpRequest.newBuilder()
                 .uri(uri)
                 .GET()
+                .timeout(timeout)
                 .build()
 
             val response = client.send(request, HttpResponse.BodyHandlers.ofString())
 
-            if (response.statusCode() == 200) {
+            if (response.statusCode() == HTTP_OK) {
                 objectMapper.readValue(response.body())
             } else {
-                logger.warn("Failed to assign variant: HTTP ${response.statusCode()} - ${response.body()}")
-                createErrorResponse(userId, experimentKey, "HTTP ${response.statusCode()}")
+                // HTTP 상태 코드별 로깅 레벨 차별화
+                val statusCode = response.statusCode()
+                when {
+                    statusCode in 400..499 -> {
+                        // 4xx: 클라이언트 에러 (잘못된 요청, 권한 없음 등)
+                        logger.warn("Client error during variant assignment: HTTP $statusCode, userId=$maskedUserId, experimentKey=$experimentKey")
+                    }
+                    statusCode in 500..599 -> {
+                        // 5xx: 서버 에러 (내부 오류, 서비스 불가 등)
+                        logger.error("Server error during variant assignment: HTTP $statusCode, userId=$maskedUserId, experimentKey=$experimentKey")
+                    }
+                    else -> {
+                        // 예상치 못한 상태 코드
+                        logger.warn("Unexpected HTTP status during variant assignment: HTTP $statusCode, userId=$maskedUserId, experimentKey=$experimentKey")
+                    }
+                }
+                createErrorResponse(userId, experimentKey, "HTTP $statusCode")
             }
+        } catch (e: HttpTimeoutException) {
+            // 타임아웃 예외 명시적 처리
+            logger.warn("Timeout during variant assignment (timeout=${timeout.toMillis()}ms): userId=$maskedUserId, experimentKey=$experimentKey", e)
+            createErrorResponse(userId, experimentKey, "Timeout after ${timeout.toMillis()}ms")
         } catch (e: Exception) {
-            logger.error("Error assigning variant for userId=$userId, experimentKey=$experimentKey", e)
+            logger.error("Error assigning variant for userId=$maskedUserId, experimentKey=$experimentKey", e)
             createErrorResponse(userId, experimentKey, e.message ?: "Unknown error")
         }
     }
@@ -92,6 +128,8 @@ class PrismClient(
      * @param eventName 이벤트 이름 (예: "purchase", "signup")
      */
     fun trackConversion(userId: String, experimentKey: String, eventName: String) {
+        val maskedUserId = maskUserId(userId)
+
         try {
             val uri = URI.create("$baseUrl/v1/conversions")
             val payload = ConversionRequest(
@@ -105,16 +143,55 @@ class PrismClient(
                 .uri(uri)
                 .header("Content-Type", "application/json")
                 .POST(HttpRequest.BodyPublishers.ofString(jsonBody))
+                .timeout(timeout)
                 .build()
 
             val response = client.send(request, HttpResponse.BodyHandlers.ofString())
 
-            if (response.statusCode() != 200) {
-                logger.warn("Failed to track conversion: HTTP ${response.statusCode()}")
+            if (response.statusCode() != HTTP_OK) {
+                // HTTP 상태 코드별 로깅 레벨 차별화
+                val statusCode = response.statusCode()
+                when {
+                    statusCode in 400..499 -> {
+                        // 4xx: 클라이언트 에러
+                        logger.warn("Client error during conversion tracking: HTTP $statusCode, userId=$maskedUserId, experimentKey=$experimentKey, eventName=$eventName")
+                    }
+                    statusCode in 500..599 -> {
+                        // 5xx: 서버 에러
+                        logger.error("Server error during conversion tracking: HTTP $statusCode, userId=$maskedUserId, experimentKey=$experimentKey, eventName=$eventName")
+                    }
+                    else -> {
+                        // 예상치 못한 상태 코드
+                        logger.warn("Unexpected HTTP status during conversion tracking: HTTP $statusCode, userId=$maskedUserId, experimentKey=$experimentKey, eventName=$eventName")
+                    }
+                }
             }
+        } catch (e: HttpTimeoutException) {
+            // 타임아웃 예외 명시적 처리
+            logger.warn("Timeout during conversion tracking (timeout=${timeout.toMillis()}ms): userId=$maskedUserId, experimentKey=$experimentKey, eventName=$eventName", e)
         } catch (e: Exception) {
-            logger.error("Error tracking conversion for userId=$userId, experimentKey=$experimentKey, eventName=$eventName", e)
+            logger.error("Error tracking conversion for userId=$maskedUserId, experimentKey=$experimentKey, eventName=$eventName", e)
             // 조용히 실패 (예외 던지지 않음)
+        }
+    }
+
+    /**
+     * 개인정보 보호를 위해 userId를 마스킹합니다.
+     *
+     * GDPR 및 개인정보 보호 규정 준수를 위해 로그에 userId를 직접 노출하지 않습니다.
+     *
+     * **마스킹 규칙:**
+     * - 4자 초과: 처음 2자 + "***" + 마지막 2자 (예: "user12345" → "us***45")
+     * - 4자 이하: 완전 마스킹 "***" (예: "abc" → "***")
+     *
+     * @param userId 원본 사용자 ID
+     * @return 마스킹된 사용자 ID
+     */
+    private fun maskUserId(userId: String): String {
+        return if (userId.length > 4) {
+            "${userId.substring(0, 2)}***${userId.substring(userId.length - 2)}"
+        } else {
+            "***"
         }
     }
 
@@ -135,7 +212,7 @@ class PrismClient(
             userId = userId,
             experimentKey = experimentKey,
             variant = null,
-            resultCode = "9999",
+            resultCode = ERROR_CODE,
             resultMessage = "Assignment failed: $errorMessage"
         )
     }

--- a/prism-sdk/src/test/kotlin/io/github/silbaram/prism/sdk/PrismClientTest.kt
+++ b/prism-sdk/src/test/kotlin/io/github/silbaram/prism/sdk/PrismClientTest.kt
@@ -51,7 +51,7 @@ class PrismClientTest {
     }
 
     @Test
-    fun `assign should return error code when experiment not found`() {
+    fun `assign should return error response when API returns error code`() {
         val jsonResponse = """
             {
                 "userId": "user123",
@@ -74,20 +74,66 @@ class PrismClientTest {
     }
 
     @Test
+    fun `assign should return error response when HTTP fails`() {
+        mockWebServer.enqueue(MockResponse().setResponseCode(500).setBody("Internal Server Error"))
+
+        val response = client.assign("user123", "exp-1")
+
+        assertEquals("user123", response.userId)
+        assertEquals("exp-1", response.experimentKey)
+        assertEquals(null, response.variant)
+        assertEquals("9999", response.resultCode)
+        assert(response.resultMessage.contains("HTTP 500"))
+    }
+
+    @Test
+    fun `assign should return error response when network fails`() {
+        mockWebServer.shutdown()
+
+        val response = client.assign("user123", "exp-1")
+
+        assertEquals("user123", response.userId)
+        assertEquals("exp-1", response.experimentKey)
+        assertEquals(null, response.variant)
+        assertEquals("9999", response.resultCode)
+        assert(response.resultMessage.contains("Assignment failed"))
+    }
+
+    @Test
     fun `trackConversion should send correct payload`() {
         mockWebServer.enqueue(MockResponse().setResponseCode(200))
 
         client.trackConversion("user123", "exp-1", "purchase")
 
         val request = mockWebServer.takeRequest()
-        assertEquals("/v1/events/conversion", request.path)
+        assertEquals("/v1/conversions", request.path)
         assertEquals("POST", request.method)
         assertEquals("application/json", request.getHeader("Content-Type"))
-        
+
         // Simple check for body content
         val body = request.body.readUtf8()
         assert(body.contains("user123"))
         assert(body.contains("exp-1"))
         assert(body.contains("purchase"))
+    }
+
+    @Test
+    fun `trackConversion should not throw exception when HTTP fails`() {
+        mockWebServer.enqueue(MockResponse().setResponseCode(500).setBody("Internal Server Error"))
+
+        // 예외가 발생하지 않아야 함
+        client.trackConversion("user123", "exp-1", "purchase")
+
+        val request = mockWebServer.takeRequest()
+        assertEquals("/v1/conversions", request.path)
+        assertEquals("POST", request.method)
+    }
+
+    @Test
+    fun `trackConversion should not throw exception when network fails`() {
+        mockWebServer.shutdown()
+
+        // 예외가 발생하지 않아야 함
+        client.trackConversion("user123", "exp-1", "purchase")
     }
 }


### PR DESCRIPTION
This pull request focuses on improving the robustness and developer experience of the Prism A/B testing SDK and API. The main changes include making the SDK fail-safe (so A/B testing failures never crash or interrupt main business logic), updating API endpoints for consistency, and enhancing documentation and test coverage to match the new behavior.

**SDK Fail-safe Improvements:**

- The `PrismClient` SDK is now designed to never throw exceptions on API or network failures. Instead, it logs errors and returns a response with `variant = null` and an error code, allowing the application to safely fall back to defaults. Conversion tracking is now fire-and-forget: failures are logged but never interrupt the main flow. [[1]](diffhunk://#diff-422d2361ca8c52be6a3e750d281c2a10efd12f7fa996e90aa6396fff3a821da5R7-R21) [[2]](diffhunk://#diff-422d2361ca8c52be6a3e750d281c2a10efd12f7fa996e90aa6396fff3a821da5R32-R55) [[3]](diffhunk://#diff-422d2361ca8c52be6a3e750d281c2a10efd12f7fa996e90aa6396fff3a821da5L32-R96) [[4]](diffhunk://#diff-422d2361ca8c52be6a3e750d281c2a10efd12f7fa996e90aa6396fff3a821da5L57-R141)
- Added SLF4J logging dependency to the SDK for error and warning logging.

**API Endpoint Consistency:**

- The conversion tracking endpoint has been changed from `/v1/events/conversion` to `/v1/conversions` (both in the API controller and SDK). This also updates the HTTP method to use a root POST on `/v1/conversions`. [[1]](diffhunk://#diff-6195f1fb217fa2cd4b0ffc74597a63ffaa40c1ab8562e830a8dd88c6a88f943dL29-R29) [[2]](diffhunk://#diff-6195f1fb217fa2cd4b0ffc74597a63ffaa40c1ab8562e830a8dd88c6a88f943dL39-R39) [[3]](diffhunk://#diff-6195f1fb217fa2cd4b0ffc74597a63ffaa40c1ab8562e830a8dd88c6a88f943dL50-R50) [[4]](diffhunk://#diff-422d2361ca8c52be6a3e750d281c2a10efd12f7fa996e90aa6396fff3a821da5L32-R96) [[5]](diffhunk://#diff-2762baf8b1c19b610b637a3c368b6d02741fe4c760bc5fe25d4b627332203431R119-R138)

**Documentation Updates:**

- The `README.md` has been expanded to clearly explain the fail-safe design of the SDK, including usage examples for both Kotlin and Java, and how to use the SDK directly without Spring Boot. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L60-R109) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R119-R183)

**Test Coverage Enhancements:**

- Added tests to ensure the SDK returns error responses (not exceptions) on HTTP or network failures for both assignment and conversion tracking, confirming the fail-safe design. [[1]](diffhunk://#diff-2762baf8b1c19b610b637a3c368b6d02741fe4c760bc5fe25d4b627332203431L54-R54) [[2]](diffhunk://#diff-2762baf8b1c19b610b637a3c368b6d02741fe4c760bc5fe25d4b627332203431R76-R109) [[3]](diffhunk://#diff-2762baf8b1c19b610b637a3c368b6d02741fe4c760bc5fe25d4b627332203431R119-R138)

**Summary of most important changes:**

**SDK Fail-safe and Logging:**
- Refactored `PrismClient` to never throw exceptions on API or network errors; instead, logs errors and returns a safe error response, and introduced SLF4J logging. [[1]](diffhunk://#diff-422d2361ca8c52be6a3e750d281c2a10efd12f7fa996e90aa6396fff3a821da5R7-R21) [[2]](diffhunk://#diff-422d2361ca8c52be6a3e750d281c2a10efd12f7fa996e90aa6396fff3a821da5R32-R55) [[3]](diffhunk://#diff-422d2361ca8c52be6a3e750d281c2a10efd12f7fa996e90aa6396fff3a821da5L32-R96) [[4]](diffhunk://#diff-422d2361ca8c52be6a3e750d281c2a10efd12f7fa996e90aa6396fff3a821da5L57-R141) [[5]](diffhunk://#diff-ae845f71d9f33464ef1776d0f9ae35c0d39a46a619102cb1e854d88276954b34R21-R23)

**API Endpoint Consistency:**
- Changed conversion tracking endpoint from `/v1/events/conversion` to `/v1/conversions` in both the API controller and SDK, and updated related test assertions. [[1]](diffhunk://#diff-6195f1fb217fa2cd4b0ffc74597a63ffaa40c1ab8562e830a8dd88c6a88f943dL29-R29) [[2]](diffhunk://#diff-6195f1fb217fa2cd4b0ffc74597a63ffaa40c1ab8562e830a8dd88c6a88f943dL39-R39) [[3]](diffhunk://#diff-6195f1fb217fa2cd4b0ffc74597a63ffaa40c1ab8562e830a8dd88c6a88f943dL50-R50) [[4]](diffhunk://#diff-422d2361ca8c52be6a3e750d281c2a10efd12f7fa996e90aa6396fff3a821da5L32-R96) [[5]](diffhunk://#diff-2762baf8b1c19b610b637a3c368b6d02741fe4c760bc5fe25d4b627332203431R119-R138)

**Documentation and Usage Examples:**
- Expanded `README.md` with detailed explanations and code samples for the SDK's fail-safe usage in both Kotlin and Java, and how to use the SDK outside of Spring Boot. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L60-R109) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R119-R183)

**Test Coverage:**
- Added tests to verify error handling and fail-safe behavior in both assignment and conversion tracking, including cases for HTTP and network failures. [[1]](diffhunk://#diff-2762baf8b1c19b610b637a3c368b6d02741fe4c760bc5fe25d4b627332203431L54-R54) [[2]](diffhunk://#diff-2762baf8b1c19b610b637a3c368b6d02741fe4c760bc5fe25d4b627332203431R76-R109) [[3]](diffhunk://#diff-2762baf8b1c19b610b637a3c368b6d02741fe4c760bc5fe25d4b627332203431R119-R138)